### PR TITLE
Support FQCN services names

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    const SERVICE_CALLABLE_NOTATION_REGEX = '/^@(?<service_id>[a-z0-9\._]+)(?:\:(?<method>[a-zA-Z_\x7f-\xff][a-z0-9_\x7f-\xff]*))?$/i';
+    const SERVICE_CALLABLE_NOTATION_REGEX = '/^@(?<service_id>[a-z0-9\._\\\]+)(?:\:(?<method>[a-zA-Z_\x7f-\xff][a-z0-9_\x7f-\xff]*))?$/iu';
     const PHP_CALLABLE_NOTATION_REGEX = '/^(?<function>(?:\\\\?[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*)+)(?:\:\:(?<method>[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*))?$/i';
 
     public function getConfigTreeBuilder()

--- a/Tests/DependencyInjection/OverblogDataLoaderExtensionTest.php
+++ b/Tests/DependencyInjection/OverblogDataLoaderExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Overblog\DataLoaderBundle\Tests\DependencyInjection;
 
+use Overblog\DataLoaderBundle\DependencyInjection\Configuration;
 use Overblog\DataLoaderBundle\DependencyInjection\OverblogDataLoaderExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Alias;
@@ -39,6 +40,21 @@ class OverblogDataLoaderExtensionTest extends TestCase
     public function tearDown()
     {
         unset($this->container, $this->extension);
+    }
+
+    public function testValidServiceCallableNodeValue()
+    {
+        $validValues = ['@app.user:getUsers', '@App\\Loader\\User:all'];
+        foreach ($validValues as $validValue) {
+            $this->assertRegExp(Configuration::SERVICE_CALLABLE_NOTATION_REGEX, $validValue);
+        }
+    }
+
+    public function testValidPhpCallableNodeValue() {
+        $validValues = ['Image\\Loader::get', 'Post::getPosts'];
+        foreach ($validValues as $validValue) {
+            $this->assertRegExp(Configuration::PHP_CALLABLE_NOTATION_REGEX, $validValue);
+        }
     }
 
     public function testUsersDataLoaderConfig()

--- a/Tests/DependencyInjection/OverblogDataLoaderExtensionTest.php
+++ b/Tests/DependencyInjection/OverblogDataLoaderExtensionTest.php
@@ -50,7 +50,8 @@ class OverblogDataLoaderExtensionTest extends TestCase
         }
     }
 
-    public function testValidPhpCallableNodeValue() {
+    public function testValidPhpCallableNodeValue()
+    {
         $validValues = ['Image\\Loader::get', 'Post::getPosts'];
         foreach ($validValues as $validValue) {
             $this->assertRegExp(Configuration::PHP_CALLABLE_NOTATION_REGEX, $validValue);


### PR DESCRIPTION
*Related issue*
#14 

I've seen that in the issue maybe you wanted to make something more advanced, using the compiler pass because the regex will not be sufficient anymore. But with the regex, it would actually fail if you do not specify a valid service name. Maybe you really don't want at the moment to use regex, but I've wanted to submit this PR anyway to see if you will be okay to use that regex in the meantime. I don't know enough how works the compiler pass so I could not try to make something more advanced, but I'll totally understand if you don't want to support FQCN services names with a simple regex ! 👍 