### PR TITLE
Clear data loaders on `kernel.reset`

### DIFF
--- a/DependencyInjection/OverblogDataLoaderExtension.php
+++ b/DependencyInjection/OverblogDataLoaderExtension.php
@@ -39,6 +39,7 @@ class OverblogDataLoaderExtension extends Extension
 
             $definition = $container->register($dataLoaderServiceID, 'Overblog\\DataLoader\\DataLoader')
                 ->setPublic(true)
+                ->addTag('kernel.reset', ['method' => 'clearAll'])
                 ->setArguments([
                     $batchLoadFn,
                     new Reference($loaderConfig['promise_adapter']),


### PR DESCRIPTION
When having a long running Symfony application it's important to clear the data loader caches when `kernel.reset` is called by Symfony. Otherwise they'll keep growing forever.