### PR TITLE
AsDataLoader attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "overblog/dataloader-php": "^0.7.0",
         "symfony/dependency-injection": "^5.3.7 || ^6.0"
     },

--- a/src/Attribute/AsDataLoader.php
+++ b/src/Attribute/AsDataLoader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\DataLoaderBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsDataLoader
+{
+    public function __construct(
+        public readonly string $alias,
+        public readonly ?int $maxBatchSize = null,
+        public readonly ?bool $batch = null,
+        public readonly ?bool $cache = null,
+    ) {
+    }
+}

--- a/src/Attribute/AsDataLoader.php
+++ b/src/Attribute/AsDataLoader.php
@@ -8,7 +8,7 @@ namespace Overblog\DataLoaderBundle\Attribute;
 final class AsDataLoader
 {
     public function __construct(
-        public readonly string $alias,
+        public readonly ?string $alias = null,
         public readonly ?int $maxBatchSize = null,
         public readonly ?bool $batch = null,
         public readonly ?bool $cache = null,

--- a/src/Attribute/AsDataLoader.php
+++ b/src/Attribute/AsDataLoader.php
@@ -12,6 +12,8 @@ final class AsDataLoader
         public readonly ?int $maxBatchSize = null,
         public readonly ?bool $batch = null,
         public readonly ?bool $cache = null,
+        public readonly ?string $cacheMap = null,
+        public readonly ?string $cacheKeyFn = null,
     ) {
     }
 }

--- a/src/Attribute/AsDataLoader.php
+++ b/src/Attribute/AsDataLoader.php
@@ -12,7 +12,6 @@ final class AsDataLoader
         public readonly ?int $maxBatchSize = null,
         public readonly ?bool $batch = null,
         public readonly ?bool $cache = null,
-        public readonly ?string $cacheMap = null,
         public readonly ?string $cacheKeyFn = null,
     ) {
     }

--- a/src/DataLoaderFnInterface.php
+++ b/src/DataLoaderFnInterface.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Overblog\DataLoaderBundle;
 
-use Overblog\PromiseAdapter\PromiseAdapterInterface;
-
 /**
  * @template K
  * @template T
+ * @template P
  */
 interface DataLoaderFnInterface
 {
     /**
      * @param array<K> $keys
-     * @return PromiseAdapterInterface<array<T>>
+     * @return P<array<T>>
      */
     public function __invoke(array $keys): mixed;
 }

--- a/src/DataLoaderFnInterface.php
+++ b/src/DataLoaderFnInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\DataLoaderBundle;
+
+/**
+ * @template K
+ * @template T
+ */
+interface DataLoaderFnInterface
+{
+    /**
+     * @param array<K> $keys
+     * @return T
+     */
+    public function __invoke(array $keys): mixed;
+}

--- a/src/DataLoaderFnInterface.php
+++ b/src/DataLoaderFnInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Overblog\DataLoaderBundle;
 
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
+
 /**
  * @template K
  * @template T
@@ -12,7 +14,7 @@ interface DataLoaderFnInterface
 {
     /**
      * @param array<K> $keys
-     * @return T
+     * @return PromiseAdapterInterface<array<T>>
      */
     public function __invoke(array $keys): mixed;
 }

--- a/src/DependencyInjection/OverblogDataLoaderExtension.php
+++ b/src/DependencyInjection/OverblogDataLoaderExtension.php
@@ -25,7 +25,7 @@ final class OverblogDataLoaderExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
 
         $configuration = $this->getConfiguration($configs, $container);
@@ -48,8 +48,7 @@ final class OverblogDataLoaderExtension extends Extension
                     $batchLoadFn,
                     new Reference($loaderConfig['promise_adapter']),
                     new Reference($OptionServiceID),
-                ])
-            ;
+                ]);
 
             if (isset($loaderConfig['factory'])) {
                 $definition->setFactory($this->buildCallableFromScalar($loaderConfig['factory']));
@@ -69,7 +68,7 @@ final class OverblogDataLoaderExtension extends Extension
 
     private function generateDataLoaderServiceIDFromName($name, ContainerBuilder $container): string
     {
-        return sprintf('%s.%s_loader', $this->getAlias(), $container->underscore($name));
+        return sprintf('%s.%s_loader', $this->getAlias(), $container::underscore($name));
     }
 
     private function generateDataLoaderOptionServiceIDFromName($name, ContainerBuilder $container): string
@@ -102,16 +101,16 @@ final class OverblogDataLoaderExtension extends Extension
             $function = new Reference($matches['service_id']);
             if (empty($matches['method'])) {
                 return $function;
-            } else {
-                return [$function, $matches['method']];
             }
+
+            return [$function, $matches['method']];
         } elseif (preg_match(Configuration::PHP_CALLABLE_NOTATION_REGEX, $scalar, $matches)) {
             $function = $matches['function'];
             if (empty($matches['method'])) {
                 return $function;
-            } else {
-                return [$function, $matches['method']];
             }
+
+            return [$function, $matches['method']];
         }
 
         return null;

--- a/src/DependencyInjection/OverblogDataLoaderExtension.php
+++ b/src/DependencyInjection/OverblogDataLoaderExtension.php
@@ -17,6 +17,10 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
+use function array_replace;
+use function preg_match;
+use function sprintf;
+
 final class OverblogDataLoaderExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void

--- a/src/OverblogDataLoaderBundle.php
+++ b/src/OverblogDataLoaderBundle.php
@@ -62,7 +62,7 @@ final class OverblogDataLoaderBundle extends Bundle
                     ContainerBuilder $container,
                     array $rawConfig,
                     string $batchLoadFn
-                ): array {
+                ): void {
                     $name = $rawConfig['alias'];
                     $dataLoaderRef = new Reference($batchLoadFn);
                     $config = [];
@@ -83,17 +83,15 @@ final class OverblogDataLoaderBundle extends Bundle
                         ->setPublic(false)
                         ->setArguments([$config]);
 
-                    return [
-                        $container->register($id, DataLoader::class)
-                            ->setPublic(true)
-                            ->addTag('kernel.reset', ['method' => 'clearAll'])
-                            ->setArguments([
-                                $dataLoaderRef,
-                                new Reference('overblog_dataloader.webonyx_graphql_sync_promise_adapter'),
-                                new Reference($OptionServiceID),
-                            ]),
-                        $id,
-                    ];
+                    $container->register($id, DataLoader::class)
+                        ->setPublic(true)
+                        ->addTag('kernel.reset', ['method' => 'clearAll'])
+                        ->setArguments([
+                            $dataLoaderRef,
+                            new Reference('overblog_dataloader.webonyx_graphql_sync_promise_adapter'),
+                            new Reference($OptionServiceID),
+                        ]);
+                    $container->registerAliasForArgument($id, DataLoaderInterface::class, $name);
                 }
 
                 private function generateDataLoaderOptionServiceIDFromName($name, ContainerBuilder $container): string
@@ -110,12 +108,11 @@ final class OverblogDataLoaderBundle extends Bundle
                 {
                     foreach ($container->findTaggedServiceIds('overblog.dataloader') as $id => $tags) {
                         foreach ($tags as $attrs) {
-                            [, $serviceId] = $this->registerDataLoader(
+                            $this->registerDataLoader(
                                 $container,
                                 $attrs,
                                 $id
                             );
-                            $container->registerAliasForArgument($serviceId, DataLoaderInterface::class, $name);
                         }
                     }
                 }

--- a/src/OverblogDataLoaderBundle.php
+++ b/src/OverblogDataLoaderBundle.php
@@ -11,14 +11,83 @@
 
 namespace Overblog\DataLoaderBundle;
 
+use Overblog\DataLoader\DataLoaderInterface;
+use Overblog\DataLoaderBundle\Attribute\AsDataLoader;
 use Overblog\DataLoaderBundle\DependencyInjection\OverblogDataLoaderExtension;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+use function sprintf;
 
 final class OverblogDataLoaderBundle extends Bundle
 {
     public function getContainerExtension(): ?ExtensionInterface
     {
         return new OverblogDataLoaderExtension();
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        $container->registerForAutoconfiguration(DataLoaderFnInterface::class)
+            ->addTag('overblog.dataloader.fn');
+
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+
+            private function registerDataLoader(
+                ContainerBuilder $container,
+                string $name,
+                array $config,
+                string $batchLoadFn
+            ): array {
+                $id = $this->generateDataLoaderServiceIDFromName($name, $container);
+                $OptionServiceID = $this->generateDataLoaderOptionServiceIDFromName($name, $container);
+                $container->register($OptionServiceID, 'Overblog\\DataLoader\\Option')
+                    ->setPublic(false)
+                    ->setArguments([$config]);
+
+                return [
+                    $container->register($id, 'Overblog\\DataLoader\\DataLoader')
+                        ->setPublic(true)
+                        ->addTag('kernel.reset', ['method' => 'clearAll'])
+                        ->setArguments([
+                            new Reference($batchLoadFn),
+                            new Reference('overblog_dataloader.react_promise_adapter'),
+                            new Reference($OptionServiceID),
+                        ]),
+                    $id,
+                ];
+            }
+
+            private function generateDataLoaderOptionServiceIDFromName($name, ContainerBuilder $container): string
+            {
+                return sprintf('%s_option', $this->generateDataLoaderServiceIDFromName($name, $container));
+            }
+
+            private function generateDataLoaderServiceIDFromName($name, ContainerBuilder $container): string
+            {
+                return sprintf('overblog_dataloader.%s_loader', $container->underscore($name));
+            }
+
+            public function process(ContainerBuilder $container)
+            {
+                foreach ($container->findTaggedServiceIds('overblog.dataloader.fn') as $id => $tags) {
+                    $serviceDefinition = $container->getDefinition($id);
+                    $class = $serviceDefinition->getClass();
+
+                    if (!$attribute = (new \ReflectionClass($class))->getAttributes(AsDataLoader::class)) {
+                        throw new \LogicException('In order to use ' . DataLoaderFnInterface::class . ' you must define ' . AsDataLoader::class . ' attribute on your class');
+                    }
+                    $attributeArgs = $attribute[0]->getArguments();
+                    $name = $attributeArgs['alias'];
+
+                    unset($attributeArgs['alias']);
+                    [, $serviceId] = $this->registerDataLoader($container, $name, $attributeArgs, new Reference($id));
+                    $container->registerAliasForArgument($serviceId, DataLoaderInterface::class, $name);
+                }
+            }
+        });
     }
 }

--- a/src/OverblogDataLoaderBundle.php
+++ b/src/OverblogDataLoaderBundle.php
@@ -11,9 +11,13 @@
 
 namespace Overblog\DataLoaderBundle;
 
+use LogicException;
+use Overblog\DataLoader\DataLoader;
 use Overblog\DataLoader\DataLoaderInterface;
+use Overblog\DataLoader\Option;
 use Overblog\DataLoaderBundle\Attribute\AsDataLoader;
 use Overblog\DataLoaderBundle\DependencyInjection\OverblogDataLoaderExtension;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -34,60 +38,70 @@ final class OverblogDataLoaderBundle extends Bundle
         $container->registerForAutoconfiguration(DataLoaderFnInterface::class)
             ->addTag('overblog.dataloader.fn');
 
-        $container->addCompilerPass(new class implements CompilerPassInterface {
+        $container->addCompilerPass(
+            new class implements CompilerPassInterface {
 
-            private function registerDataLoader(
-                ContainerBuilder $container,
-                string $name,
-                array $config,
-                string $batchLoadFn
-            ): array {
-                $id = $this->generateDataLoaderServiceIDFromName($name, $container);
-                $OptionServiceID = $this->generateDataLoaderOptionServiceIDFromName($name, $container);
-                $container->register($OptionServiceID, 'Overblog\\DataLoader\\Option')
-                    ->setPublic(false)
-                    ->setArguments([$config]);
+                private function registerDataLoader(
+                    ContainerBuilder $container,
+                    string $name,
+                    array $config,
+                    string $batchLoadFn
+                ): array {
+                    $id = $this->generateDataLoaderServiceIDFromName($name, $container);
+                    $OptionServiceID = $this->generateDataLoaderOptionServiceIDFromName($name, $container);
+                    $container->register($OptionServiceID, Option::class)
+                        ->setPublic(false)
+                        ->setArguments([$config]);
 
-                return [
-                    $container->register($id, 'Overblog\\DataLoader\\DataLoader')
-                        ->setPublic(true)
-                        ->addTag('kernel.reset', ['method' => 'clearAll'])
-                        ->setArguments([
-                            new Reference($batchLoadFn),
-                            new Reference('overblog_dataloader.react_promise_adapter'),
-                            new Reference($OptionServiceID),
-                        ]),
-                    $id,
-                ];
-            }
+                    return [
+                        $container->register($id, DataLoader::class)
+                            ->setPublic(true)
+                            ->addTag('kernel.reset', ['method' => 'clearAll'])
+                            ->setArguments([
+                                new Reference($batchLoadFn),
+                                new Reference('overblog_dataloader.webonyx_graphql_sync_promise_adapter'),
+                                new Reference($OptionServiceID),
+                            ]),
+                        $id,
+                    ];
+                }
 
-            private function generateDataLoaderOptionServiceIDFromName($name, ContainerBuilder $container): string
-            {
-                return sprintf('%s_option', $this->generateDataLoaderServiceIDFromName($name, $container));
-            }
+                private function generateDataLoaderOptionServiceIDFromName($name, ContainerBuilder $container): string
+                {
+                    return sprintf('%s_option', $this->generateDataLoaderServiceIDFromName($name, $container));
+                }
 
-            private function generateDataLoaderServiceIDFromName($name, ContainerBuilder $container): string
-            {
-                return sprintf('overblog_dataloader.%s_loader', $container->underscore($name));
-            }
+                private function generateDataLoaderServiceIDFromName($name, ContainerBuilder $container): string
+                {
+                    return sprintf('overblog_dataloader.%s_loader', $container::underscore($name));
+                }
 
-            public function process(ContainerBuilder $container)
-            {
-                foreach ($container->findTaggedServiceIds('overblog.dataloader.fn') as $id => $tags) {
-                    $serviceDefinition = $container->getDefinition($id);
-                    $class = $serviceDefinition->getClass();
+                public function process(ContainerBuilder $container)
+                {
+                    foreach ($container->findTaggedServiceIds('overblog_dataloader.dataloader.fn') as $id => $tags) {
+                        $serviceDefinition = $container->getDefinition($id);
+                        $class = $serviceDefinition->getClass();
 
-                    if (!$attribute = (new \ReflectionClass($class))->getAttributes(AsDataLoader::class)) {
-                        throw new \LogicException('In order to use ' . DataLoaderFnInterface::class . ' you must define ' . AsDataLoader::class . ' attribute on your class');
+                        $attribute = (new ReflectionClass($class))->getAttributes(AsDataLoader::class);
+                        if (!$attribute) {
+                            throw new LogicException(
+                                'In order to use ' . DataLoaderFnInterface::class . ' you must define ' . AsDataLoader::class . ' attribute on your class'
+                            );
+                        }
+                        $attributeArgs = $attribute[0]->getArguments();
+                        $name = $attributeArgs['alias'];
+
+                        unset($attributeArgs['alias']);
+                        [, $serviceId] = $this->registerDataLoader(
+                            $container,
+                            $name,
+                            $attributeArgs,
+                            new Reference($id)
+                        );
+                        $container->registerAliasForArgument($serviceId, DataLoaderInterface::class, $name);
                     }
-                    $attributeArgs = $attribute[0]->getArguments();
-                    $name = $attributeArgs['alias'];
-
-                    unset($attributeArgs['alias']);
-                    [, $serviceId] = $this->registerDataLoader($container, $name, $attributeArgs, new Reference($id));
-                    $container->registerAliasForArgument($serviceId, DataLoaderInterface::class, $name);
                 }
             }
-        });
+        );
     }
 }

--- a/src/OverblogDataLoaderBundle.php
+++ b/src/OverblogDataLoaderBundle.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Overblog\DataLoaderBundle;
 
 use LogicException;
@@ -47,6 +49,13 @@ final class OverblogDataLoaderBundle extends Bundle
                     array $config,
                     string $batchLoadFn
                 ): array {
+                    if (isset($config['cacheMap'])) {
+                        $config['cacheMap'] = new Reference($config['cacheMap']);
+                    }
+                    if (isset($config['cacheKeyFn'])) {
+                        $config['cacheKeyFn'] = new Reference($config['cacheKeyFn']);
+                    }
+
                     $id = $this->generateDataLoaderServiceIDFromName($name, $container);
                     $OptionServiceID = $this->generateDataLoaderOptionServiceIDFromName($name, $container);
                     $container->register($OptionServiceID, Option::class)
@@ -96,7 +105,7 @@ final class OverblogDataLoaderBundle extends Bundle
                             $container,
                             $name,
                             $attributeArgs,
-                            new Reference($id)
+                            $id
                         );
                         $container->registerAliasForArgument($serviceId, DataLoaderInterface::class, $name);
                     }

--- a/src/OverblogDataLoaderBundle.php
+++ b/src/OverblogDataLoaderBundle.php
@@ -87,7 +87,7 @@ final class OverblogDataLoaderBundle extends Bundle
 
                 public function process(ContainerBuilder $container)
                 {
-                    foreach ($container->findTaggedServiceIds('overblog_dataloader.dataloader.fn') as $id => $tags) {
+                    foreach ($container->findTaggedServiceIds('overblog.dataloader.fn') as $id => $tags) {
                         $serviceDefinition = $container->getDefinition($id);
                         $class = $serviceDefinition->getClass();
 


### PR DESCRIPTION
Hello, this is proposal to add attribute and interface

```
#[AsDataLoader(alias: 'shape')]
class ShapeLoader implements DataLoaderFnInterface
```

which will be used for autoregistering and autowiring of DataLoaders.

The idea is that `alias` will be used as autowiring name/target, so you don't need to register DataLoaders in bundle config.

```
public function __construct(private DataLoaderInterface $shape)
{
}
``` 

What do you think? 